### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/danmarius8940/1de59d13-e7ff-4036-bfc0-0cd657f5c830/a5366b4f-d26d-43d4-bfbf-93659b3dab0c/_apis/work/boardbadge/7e833190-31e4-4458-84cf-9f28996c7bb7)](https://dev.azure.com/danmarius8940/1de59d13-e7ff-4036-bfc0-0cd657f5c830/_boards/board/t/a5366b4f-d26d-43d4-bfbf-93659b3dab0c/Microsoft.RequirementCategory)
 # PartsUnlimited
 
 This is an Azure Pipelines project.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#63](https://dev.azure.com/danmarius8940/1de59d13-e7ff-4036-bfc0-0cd657f5c830/_workitems/edit/63). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.